### PR TITLE
Feature: add revert reason to receipt

### DIFF
--- a/src/confirm.rs
+++ b/src/confirm.rs
@@ -4,7 +4,7 @@ use crate::{
     api::{Eth, EthFilter, Namespace},
     error,
     types::{Bytes, TransactionReceipt, TransactionRequest, H256, U64},
-    Transport,
+    Error, Transport,
 };
 use futures::{Future, StreamExt};
 use std::time::Duration;
@@ -68,6 +68,26 @@ async fn transaction_receipt_block_number_check<T: Transport>(eth: &Eth<T>, hash
     Ok(receipt.and_then(|receipt| receipt.block_number))
 }
 
+async fn decode_revert_reason(revert_reason_abi: &str) -> error::Result<String> {
+    let method_id_len = 10;
+    let block_len = 64;
+
+    // remove method id and data offset
+    let cleaned_abi = &revert_reason_abi[method_id_len + block_len..];
+
+    let len_hex = &cleaned_abi[..block_len];
+    let reason_len = 2 * usize::from_str_radix(len_hex, 16)
+        .map_err(|err| Error::Decoder(format!("{:?}", err)))?;
+
+    let reason_hex = &cleaned_abi[block_len..block_len + reason_len];
+    let decoded_reason = hex::decode(&reason_hex)
+        .map_err(|err| Error::Decoder(format!("{:?}", err)))?;
+    let reason_str = String::from_utf8(decoded_reason)
+        .map_err(|err| Error::Decoder(format!("{:?}", err)))?;
+
+    Ok(reason_str)
+}
+
 async fn send_transaction_with_confirmation_<T: Transport>(
     hash: H256,
     transport: T,
@@ -86,6 +106,14 @@ async fn send_transaction_with_confirmation_<T: Transport>(
         .transaction_receipt(hash)
         .await?
         .expect("receipt can't be null after wait for confirmations; qed");
+
+    if receipt.status == Some(0.into()) {
+        if let Some(revert_reason_abi) = receipt.revert_reason.as_deref() {
+            let revert_reason = decode_revert_reason(revert_reason_abi).await?;
+            return Err(Error::Revert(revert_reason));
+        }
+    }
+
     Ok(receipt)
 }
 
@@ -119,7 +147,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::send_transaction_with_confirmation;
+    use super::{decode_revert_reason, send_transaction_with_confirmation};
     use crate::{
         rpc::Value,
         transports::test::TestTransport,
@@ -163,6 +191,7 @@ mod tests {
             logs_bloom: Default::default(),
             transaction_type: None,
             effective_gas_price: Default::default(),
+            revert_reason: None,
         };
 
         let poll_interval = Duration::from_secs(0);
@@ -222,5 +251,16 @@ mod tests {
         );
         transport.assert_no_more_requests();
         assert_eq!(confirmation, Ok(transaction_receipt));
+    }
+
+    #[tokio::test]
+    async fn test_decode_revert_reason() {
+        // example from solidity docs
+        let revert_reason_abi = "0x08c379a00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000001a4e6f7420656e6f7567682045746865722070726f76696465642e000000000000";
+        let expected_revert_reason = "Not enough Ether provided.";
+
+        let decoded_revert_reason = decode_revert_reason(revert_reason_abi).await.unwrap();
+
+        assert_eq!(expected_revert_reason, decoded_revert_reason);
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,13 +47,17 @@ pub enum Error {
     /// web3 internal error
     #[display(fmt = "Internal Web3 error")]
     Internal,
+    /// Transaction reverted
+    #[display(fmt = "Transaction reverted: {}", _0)]
+    #[from(ignore)]
+    Revert(String),
 }
 
 impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         use self::Error::*;
         match *self {
-            Unreachable | Decoder(_) | InvalidResponse(_) | Transport { .. } | Internal => None,
+            Unreachable | Decoder(_) | InvalidResponse(_) | Transport { .. } | Internal | Revert(_) => None,
             Rpc(ref e) => Some(e),
             Io(ref e) => Some(e),
             Recovery(ref e) => Some(e),
@@ -79,6 +83,7 @@ impl Clone for Error {
             Io(e) => Io(IoError::from(e.kind())),
             Recovery(e) => Recovery(e.clone()),
             Internal => Internal,
+            Revert(s) => Revert(s.clone()),
         }
     }
 }
@@ -94,6 +99,7 @@ impl PartialEq for Error {
             (Rpc(a), Rpc(b)) => a == b,
             (Io(a), Io(b)) => a.kind() == b.kind(),
             (Recovery(a), Recovery(b)) => a == b,
+            (Revert(a), Revert(b)) => a == b,
             _ => false,
         }
     }

--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -114,6 +114,7 @@ pub struct Receipt {
 }
 
 impl Receipt {
+    /// Checks transaction execution reverted
     pub fn is_txn_reverted(&self) -> bool {
         self.status == Some(0.into())
     }

--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -108,6 +108,9 @@ pub struct Receipt {
     /// Effective gas price
     #[serde(rename = "effectiveGasPrice")]
     pub effective_gas_price: Option<U256>,
+    /// Transaction revert reason
+    #[serde(rename = "revertReason")]
+    pub revert_reason: Option<String>,
 }
 
 /// Raw bytes of a signed, but not yet sent transaction

--- a/src/types/transaction.rs
+++ b/src/types/transaction.rs
@@ -113,6 +113,12 @@ pub struct Receipt {
     pub revert_reason: Option<String>,
 }
 
+impl Receipt {
+    pub fn is_txn_reverted(&self) -> bool {
+        self.status == Some(0.into())
+    }
+}
+
 /// Raw bytes of a signed, but not yet sent transaction
 #[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RawTransaction {


### PR DESCRIPTION
Changes:
- Added optional `revert_reason` String to receipt
- Added decoding for it
- Added test for it, matching Solidity docs

Reasoning: 
`revert(...)`, as described in [Solidity docs](https://docs.soliditylang.org/en/v0.8.12/control-structures.html#revert), can return a revert reason as an ABI-encoded string. Some Ethereum clients already have this functionality (e.g. [Hyperledger Besu](https://besu.hyperledger.org/private-networks/how-to/send-transactions/revert-reason)), while in others it may be added later.